### PR TITLE
Fixed to stop watching the file descriptor

### DIFF
--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -1,5 +1,8 @@
 
-import asyncio
+try:
+    import asyncio
+except ImportError:
+    import trollius as asyncio
 import pycares
 
 from . import error

--- a/tests.py
+++ b/tests.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 
 import sys
-import asyncio
+try:
+    import asyncio
+except ImportError:
+    import trollius as asyncio
 import unittest
 
 import aiodns
@@ -108,7 +111,7 @@ class DNSTest(unittest.TestCase):
 #            self.assertTrue(e)
 
     def test_query_twice(self):
-        if sys.version[:3] >= '3.4':
+        if sys.version[:3] >= '3.3':
             exec('''if 1:
             @asyncio.coroutine
             def coro(self, host, qtype, n=2):


### PR DESCRIPTION
There is a bug that a timeout error occurred when querying twice on coroutine.
My environment are Python 3.4.1 and Ubuntu 14.04.1 LTS.
