### PR TITLE
setup: Fix decoding in non-UTF-8 environments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import codecs
 import re
 import sys
 
@@ -28,7 +29,7 @@ setup(name             = "aiodns",
       author_email     = "saghul@gmail.com",
       url              = "http://github.com/saghul/aiodns",
       description      = "Simple DNS resolver for asyncio",
-      long_description = open("README.rst").read(),
+      long_description = codecs.open("README.rst", encoding="utf-8").read(),
       install_requires = install_requires,
       packages         = ['aiodns'],
       platforms        = ["POSIX", "Microsoft Windows"],


### PR DESCRIPTION
I have been hitting this issue while packaging aiodns for Exherbo:
all our builds are done in sandboxes where LANG=C

Note that this fix is for Python 3 only.
As I'm not a Python developer, I will let you find a solution compatible with 2.7
