### PR TITLE
Use c-ares event thread when available

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,15 @@ The API is pretty simple, three functions are provided in the ``DNSResolver`` cl
 Note for Windows users
 ======================
 
-This library requires the asyncio loop to be a `SelectorEventLoop`, which is not the default on Windows.
+This library requires the use of an ``asyncio.SelectorEventLoop`` on Windows
+**only** when using a custom build of ``pycares`` that links against a system-
+provided ``c-ares`` library **without** thread-safety support. This is because
+non-thread-safe builds of ``c-ares`` are incompatible with the default
+``ProactorEventLoop`` on Windows.
+
+If you're using the official prebuilt ``pycares`` wheels (version 4.7.0 or
+later), which include a thread-safe version of ``c-ares``, this limitation does
+**not** apply and can be safely ignored.
 
 The default can be changed as follows (do this very early in your application):
 

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ If you're using the official prebuilt ``pycares`` wheels (version 4.7.0 or
 later), which include a thread-safe version of ``c-ares``, this limitation does
 **not** apply and can be safely ignored.
 
-The default can be changed as follows (do this very early in your application):
+The default event loop can be changed as follows (do this very early in your application):
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ provided ``c-ares`` library **without** thread-safety support. This is because
 non-thread-safe builds of ``c-ares`` are incompatible with the default
 ``ProactorEventLoop`` on Windows.
 
-If you're using the official prebuilt ``pycares`` wheels (version 4.7.0 or
+If you're using the official prebuilt ``pycares`` wheels on PyPI (version 4.7.0 or
 later), which include a thread-safe version of ``c-ares``, this limitation does
 **not** apply and can be safely ignored.
 

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -63,16 +63,15 @@ class DNSResolver:
                                             timeout=timeout,
                                             **kwargs)
         else:
-            if sys.platform == 'win32':
-                if not isinstance(self.loop, asyncio.SelectorEventLoop):
-                    try:
-                        import winloop
-                        if not isinstance(self.loop , winloop.Loop):
-                            raise RuntimeError(
-                                'aiodns needs a SelectorEventLoop on Windows. See more: https://github.com/saghul/aiodns/issues/86')
-                    except ModuleNotFoundError:
+            if sys.platform == 'win32' and not isinstance(self.loop, asyncio.SelectorEventLoop):
+                try:
+                    import winloop
+                    if not isinstance(self.loop , winloop.Loop):
                         raise RuntimeError(
                             'aiodns needs a SelectorEventLoop on Windows. See more: https://github.com/saghul/aiodns/issues/86')
+                except ModuleNotFoundError:
+                    raise RuntimeError(
+                        'aiodns needs a SelectorEventLoop on Windows. See more: https://github.com/saghul/aiodns/issues/86')
             self._channel = pycares.Channel(sock_state_cb=self._sock_state_cb,
                                             timeout=timeout,
                                             **kwargs)

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -104,9 +104,11 @@ class DNSResolver:
         cb: Callable[[Any, int], Union[asyncio.Handle, None]]
         future: "asyncio.Future[Any]" = self.loop.create_future()
         if self._event_thread:
-            cb = functools.partial(self.loop.call_soon_threadsafe, self._callback, future)
+            def cb(result: Any, errorno: int) -> asyncio.Handle:
+                return self.loop.call_soon_threadsafe(self._callback, result, errorno)
         else:
-            cb = functools.partial(self._callback, future)
+            def cb(result: Any, errorno: int) -> None:
+                return self._callback(future, result, errorno)
         return future, cb
 
     def query(self, host: str, qtype: str, qclass: Optional[str]=None) -> asyncio.Future:

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -101,7 +101,7 @@ class DNSResolver:
 
     def _get_future_callback(self) -> Tuple["asyncio.Future[Any]", Callable[[Any, int], asyncio.Handle | None]]:
         """Return a future and a callback to set the result of the future."""
-        cb: Callable[[Any, int], asyncio.Handle | None]
+        cb: Callable[[Any, int], Union[asyncio.Handle, None]]
         future: "asyncio.Future[Any]" = self.loop.create_future()
         if self._event_thread:
             cb = functools.partial(self.loop.call_soon_threadsafe, self._callback, future)

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -22,6 +22,11 @@ __version__ = '3.2.0'
 
 __all__ = ('DNSResolver', 'error')
 
+WINDOWS_SELECTOR_ERR_MSG = (
+    "aiodns needs a SelectorEventLoop on Windows. See more: "
+    "https://github.com/aio-libs/aiodns#note-for-windows-users"
+)
+
 
 READ = 1
 WRITE = 2
@@ -67,11 +72,9 @@ class DNSResolver:
                 try:
                     import winloop
                     if not isinstance(self.loop , winloop.Loop):
-                        raise RuntimeError(
-                            'aiodns needs a SelectorEventLoop on Windows. See more: https://github.com/saghul/aiodns/issues/86')
+                        raise RuntimeError(WINDOWS_SELECTOR_ERR_MSG)
                 except ModuleNotFoundError:
-                    raise RuntimeError(
-                        'aiodns needs a SelectorEventLoop on Windows. See more: https://github.com/saghul/aiodns/issues/86')
+                    raise RuntimeError(WINDOWS_SELECTOR_ERR_MSG)
             self._channel = pycares.Channel(sock_state_cb=self._sock_state_cb,
                                             timeout=timeout,
                                             **kwargs)

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -103,9 +103,9 @@ class DNSResolver:
         cb: Callable[[Any, int], None]
         future: "asyncio.Future[Any]" = self.loop.create_future()
         if self._event_thread:
-            cb = functools.partial(  # type: ignore[assignment, arg-type]
+            cb = functools.partial(  # type: ignore[assignment]
                 self.loop.call_soon_threadsafe,
-                self._callback,
+                self._callback,  # type: ignore[arg-type]
                 future
             )
         else:

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -102,7 +102,7 @@ class DNSResolver:
     def _get_future_callback(self) -> Tuple[asyncio.Future, Callable[[Any, int], asyncio.Handle | None]]:
         """Return a future and a callback to set the result of the future."""
         cb: Callable[[Any, int], asyncio.Handle | None]
-        future: asyncio.Future[Any] = self.loop.create_future()
+        future: "asyncio.Future[Any]" = self.loop.create_future()
         if self._event_thread:
             cb = functools.partial(self.loop.call_soon_threadsafe, self._callback, future)
         else:

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -99,7 +99,7 @@ class DNSResolver:
         else:
             fut.set_result(result)
 
-    def _get_future_callback(self) -> Tuple[asyncio.Future, Callable[[Any, int], None]]:
+    def _get_future_callback(self) -> Tuple[asyncio.Future, Callable[[Any, int], asyncio.Handle | None]]:
         """Return a future and a callback to set the result of the future."""
         future = self.loop.create_future()  # type: asyncio.Future
         if self._event_thread:

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -99,7 +99,7 @@ class DNSResolver:
         else:
             fut.set_result(result)
 
-    def _get_future_callback(self) -> Tuple[asyncio.Future, Callable[[Any, int], asyncio.Handle | None]]:
+    def _get_future_callback(self) -> Tuple["asyncio.Future[Any]", Callable[[Any, int], asyncio.Handle | None]]:
         """Return a future and a callback to set the result of the future."""
         cb: Callable[[Any, int], asyncio.Handle | None]
         future: "asyncio.Future[Any]" = self.loop.create_future()

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -120,8 +120,7 @@ class DNSResolver:
             except KeyError:
                 raise ValueError('invalid query class: {}'.format(qclass))
 
-        fut = self.loop.create_future()  # type: asyncio.Future
-        cb = functools.partial(self._callback, fut)
+        fut, cb = self._get_future_callback()
         self._channel.query(host, qtype, cb, query_class=qclass)
         return fut
 

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -104,11 +104,9 @@ class DNSResolver:
         cb: Callable[[Any, int], Union[asyncio.Handle, None]]
         future: "asyncio.Future[Any]" = self.loop.create_future()
         if self._event_thread:
-            def cb(result: Any, errorno: int) -> asyncio.Handle:
-                return self.loop.call_soon_threadsafe(self._callback, result, errorno)
+            cb = functools.partial(self.loop.call_soon_threadsafe, self._callback, future)  # type: ignore[arg-type]
         else:
-            def cb(result: Any, errorno: int) -> None:
-                return self._callback(future, result, errorno)
+            cb = functools.partial(self._callback, future)
         return future, cb
 
     def query(self, host: str, qtype: str, qclass: Optional[str]=None) -> asyncio.Future:

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -103,7 +103,7 @@ class DNSResolver:
         cb: Callable[[Any, int], None]
         future: "asyncio.Future[Any]" = self.loop.create_future()
         if self._event_thread:
-            cb = functools.partial(self.loop.call_soon_threadsafe, self._callback, future)  # type: ignore[arg-type]
+            cb = functools.partial(self.loop.call_soon_threadsafe, self._callback, future)  # type: ignore[return-value, arg-type]
         else:
             cb = functools.partial(self._callback, future)
         return future, cb

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -98,7 +98,7 @@ class DNSResolver:
         else:
             fut.set_result(result)
 
-    def _get_future_callback(self) -> Tuple["asyncio.Future[Any]", Callable[[Any, int], asyncio.Handle | None]]:
+    def _get_future_callback(self) -> Tuple["asyncio.Future[Any]", Callable[[Any, int], None]]:
         """Return a future and a callback to set the result of the future."""
         cb: Callable[[Any, int], Union[asyncio.Handle, None]]
         future: "asyncio.Future[Any]" = self.loop.create_future()

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -103,7 +103,11 @@ class DNSResolver:
         cb: Callable[[Any, int], None]
         future: "asyncio.Future[Any]" = self.loop.create_future()
         if self._event_thread:
-            cb = functools.partial(self.loop.call_soon_threadsafe, self._callback, future)  # type: ignore[return-value, arg-type]
+            cb = functools.partial(  # type: ignore[assignment, arg-type]
+                self.loop.call_soon_threadsafe,
+                self._callback,
+                future
+            )
         else:
             cb = functools.partial(self._callback, future)
         return future, cb

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -101,7 +101,8 @@ class DNSResolver:
 
     def _get_future_callback(self) -> Tuple[asyncio.Future, Callable[[Any, int], asyncio.Handle | None]]:
         """Return a future and a callback to set the result of the future."""
-        future = self.loop.create_future()  # type: asyncio.Future
+        cb: Callable[[Any, int], asyncio.Handle | None]
+        future: asyncio.Future[Any] = self.loop.create_future()
         if self._event_thread:
             cb = functools.partial(self.loop.call_soon_threadsafe, self._callback, future)
         else:

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -59,7 +59,7 @@ class DNSResolver:
         self._event_thread = hasattr(pycares,"ares_threadsafety") and pycares.ares_threadsafety()
         if self._event_thread:
             # pycares is thread safe
-            self._channel = pycares.Channel(sock_state_cb=self._sock_state_cb,
+            self._channel = pycares.Channel(event_thread=True,
                                             timeout=timeout,
                                             **kwargs)
         else:
@@ -73,7 +73,7 @@ class DNSResolver:
                     except ModuleNotFoundError:
                         raise RuntimeError(
                             'aiodns needs a SelectorEventLoop on Windows. See more: https://github.com/saghul/aiodns/issues/86')
-            self._channel = pycares.Channel(event_thread=True,
+            self._channel = pycares.Channel(sock_state_cb=self._sock_state_cb,
                                             timeout=timeout,
                                             **kwargs)
         if nameservers:

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -100,7 +100,7 @@ class DNSResolver:
 
     def _get_future_callback(self) -> Tuple["asyncio.Future[Any]", Callable[[Any, int], None]]:
         """Return a future and a callback to set the result of the future."""
-        cb: Callable[[Any, int], Union[asyncio.Handle, None]]
+        cb: Callable[[Any, int], None]
         future: "asyncio.Future[Any]" = self.loop.create_future()
         if self._event_thread:
             cb = functools.partial(self.loop.call_soon_threadsafe, self._callback, future)  # type: ignore[arg-type]

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -3,6 +3,7 @@
 import asyncio
 import ipaddress
 import unittest
+import pytest
 import socket
 import sys
 import time
@@ -222,15 +223,13 @@ class TestNoEventThreadDNS(DNSTest):
 
 
 @unittest.skipIf(sys.platform != 'win32', 'Only run on Windows')
-class TestWinDNSWithoutSelectorOrEventThread(DNSTest):
-    """Test DNSResolver with no event thread and no selector."""
-
-    def setUp(self):
-        with unittest.mock.patch('aiodns.pycares.ares_threadsafety', return_value=False):
-            self.loop = asyncio.new_event_loop()
-            self.addCleanup(self.loop.close)
-            self.resolver = aiodns.DNSResolver(loop=self.loop, timeout=5.0)
-            self.resolver.nameservers = ['8.8.8.8']
+def test_win32_no_selector_event_loop():
+    """Test DNSResolver with Windows without SelectorEventLoop."""
+    with ( 
+        pytest.raises(RuntimeError, match="aiodns needs a SelectorEventLoop on Windows"),
+        unittest.mock.patch('aiodns.pycares.ares_threadsafety', return_value=False)
+    ):
+        aiodns.DNSResolver(loop=asyncio.new_event_loop(), timeout=5.0)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -225,7 +225,8 @@ class TestNoEventThreadDNS(DNSTest):
 @unittest.skipIf(sys.platform != 'win32', 'Only run on Windows')
 def test_win32_no_selector_event_loop():
     """Test DNSResolver with Windows without SelectorEventLoop."""
-    with ( 
+    asyncio.set_event_loop_policy(asyncio.DefaultEventLoopPolicy())
+    with (
         pytest.raises(RuntimeError, match="aiodns needs a SelectorEventLoop on Windows"),
         unittest.mock.patch('aiodns.pycares.ares_threadsafety', return_value=False)
     ):

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -6,6 +6,7 @@ import unittest
 import socket
 import sys
 import time
+import unittest.mock
 
 import aiodns
 
@@ -210,6 +211,13 @@ class TestUV_DNS(DNSTest):
         self.addCleanup(self.loop.close)
         self.resolver = aiodns.DNSResolver(loop=self.loop, timeout=5.0)
         self.resolver.nameservers = ['8.8.8.8']
+
+class TestNoEventThreadDNS(DNSTest):
+    """Test DNSResolver with no event thread."""
+    
+    def setUp(self):
+        with unittest.mock.patch('aiodns.pycares.ares_threadsafety', return_value=False):
+            super().setUp()
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main(verbosity=2)

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -214,7 +214,7 @@ class TestUV_DNS(DNSTest):
 
 class TestNoEventThreadDNS(DNSTest):
     """Test DNSResolver with no event thread."""
-    
+
     def setUp(self):
         with unittest.mock.patch('aiodns.pycares.ares_threadsafety', return_value=False):
             super().setUp()

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -212,12 +212,26 @@ class TestUV_DNS(DNSTest):
         self.resolver = aiodns.DNSResolver(loop=self.loop, timeout=5.0)
         self.resolver.nameservers = ['8.8.8.8']
 
+
 class TestNoEventThreadDNS(DNSTest):
     """Test DNSResolver with no event thread."""
 
     def setUp(self):
         with unittest.mock.patch('aiodns.pycares.ares_threadsafety', return_value=False):
             super().setUp()
+
+
+@unittest.skipIf(sys.platform != 'win32', 'Only run on Windows')
+class TestWinDNSWithoutSelectorOrEventThread(DNSTest):
+    """Test DNSResolver with no event thread and no selector."""
+
+    def setUp(self):
+        with unittest.mock.patch('aiodns.pycares.ares_threadsafety', return_value=False):
+            self.loop = asyncio.new_event_loop()
+            self.addCleanup(self.loop.close)
+            self.resolver = aiodns.DNSResolver(loop=self.loop, timeout=5.0)
+            self.resolver.nameservers = ['8.8.8.8']
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

If `pycares` is thread-safe and supports the event thread, use it as its now the [recommended way -- see Event Thread example (recommended)](https://c-ares.org/docs.html) to run c-ares (per their docs).


## Are there changes in behavior for the user?

This change should be fully transparent to users.

It no longer depends on a specific event loop implementation—any event loop will work, including non-selector loops—provided that c-ares is compiled with thread-safety enabled (which is the case for most modern versions).

While context switch overhead is slightly higher (~0.9–3.2 µs vs. ~0.3–1.2 µs in rough, non-scientific tests) compared to handling reads/writes directly in the event loop, overall performance should be comparable or better. That's because the threading is handled in native code, and the cost of performing reads/writes in Python likely outweighs the marginal increase in context switching time.

## Related issue number

fixes #124
fixes #122

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
