### PR TITLE
Fix return type signature for CNAME and SOA records

### DIFF
--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -204,7 +204,7 @@ class DNSResolver:
 
     def query(
         self, host: str, qtype: str, qclass: Optional[str] = None
-    ) -> asyncio.Future[list[Any] | Any]:
+    ) -> asyncio.Future[list[Any]] | asyncio.Future[Any]:
         try:
             qtype = query_type_map[qtype]
         except KeyError as e:
@@ -215,7 +215,7 @@ class DNSResolver:
             except KeyError as e:
                 raise ValueError(f'invalid query class: {qclass}') from e
 
-        fut: asyncio.Future[list[Any] | Any]
+        fut: asyncio.Future[list[Any]] | asyncio.Future[Any]
         fut, cb = self._get_future_callback()
         self._channel.query(host, qtype, cb, query_class=qclass)
         return fut

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -172,7 +172,7 @@ class DNSResolver:
     @overload
     def query(
         self, host: str, qtype: Literal['CNAME'], qclass: Optional[str] = ...
-    ) -> asyncio.Future[list[pycares.ares_query_cname_result]]: ...
+    ) -> asyncio.Future[pycares.ares_query_cname_result]: ...
     @overload
     def query(
         self, host: str, qtype: Literal['MX'], qclass: Optional[str] = ...
@@ -192,7 +192,7 @@ class DNSResolver:
     @overload
     def query(
         self, host: str, qtype: Literal['SOA'], qclass: Optional[str] = ...
-    ) -> asyncio.Future[list[pycares.ares_query_soa_result]]: ...
+    ) -> asyncio.Future[pycares.ares_query_soa_result]: ...
     @overload
     def query(
         self, host: str, qtype: Literal['SRV'], qclass: Optional[str] = ...
@@ -204,7 +204,7 @@ class DNSResolver:
 
     def query(
         self, host: str, qtype: str, qclass: Optional[str] = None
-    ) -> asyncio.Future[list[Any]]:
+    ) -> asyncio.Future[list[Any] | Any]:
         try:
             qtype = query_type_map[qtype]
         except KeyError as e:
@@ -215,7 +215,7 @@ class DNSResolver:
             except KeyError as e:
                 raise ValueError(f'invalid query class: {qclass}') from e
 
-        fut: asyncio.Future[list[Any]]
+        fut: asyncio.Future[list[Any] | Any]
         fut, cb = self._get_future_callback()
         self._channel.query(host, qtype, cb, query_class=qclass)
         return fut

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -204,7 +204,7 @@ class DNSResolver:
 
     def query(
         self, host: str, qtype: str, qclass: Optional[str] = None
-    ) -> asyncio.Future[list[Any]] | asyncio.Future[Any]:
+    ) -> Union[asyncio.Future[list[Any]], asyncio.Future[Any]]:
         try:
             qtype = query_type_map[qtype]
         except KeyError as e:
@@ -215,7 +215,7 @@ class DNSResolver:
             except KeyError as e:
                 raise ValueError(f'invalid query class: {qclass}') from e
 
-        fut: asyncio.Future[list[Any]] | asyncio.Future[Any]
+        fut: Union[asyncio.Future[list[Any]], asyncio.Future[Any]]
         fut, cb = self._get_future_callback()
         self._channel.query(host, qtype, cb, query_class=qclass)
         return fut


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Fixes the return type signature of DNSResolver query to not lie to users about what is returned. Properly reflects what Pycares actually returns for each query type.

## Are there changes in behavior for the user?
Return type signature now matches reality of what is returned

## Related issue number
Fixes #161 

## Checklist

- [x] I think the code is well written
- [] Unit tests for the changes exist
- [] Documentation reflects the changes

Change does not change library functionality.