### PR TITLE
Provide more accurate information on what eventloops are supported on windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ The API is pretty simple, three functions are provided in the ``DNSResolver`` cl
 Note for Windows users
 ======================
 
-This library requires the use of an ``asyncio.SelectorEventLoop`` on Windows
+This library requires the use of an ``asyncio.SelectorEventLoop`` or ``winloop`` on Windows
 **only** when using a custom build of ``pycares`` that links against a system-
 provided ``c-ares`` library **without** thread-safety support. This is because
 non-thread-safe builds of ``c-ares`` are incompatible with the default


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This project uses `winloop` but the documentation contains no mention of that and might force users to only use the `asyncio.SelectorEventLoopPolicy` which can cause some confusion for users who might want to use winloop.

## Are there changes in behavior for the user?

Only behavior changed is documentation. 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
