### PR TITLE
Add explict close method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ The following query types are supported: A, AAAA, ANY, CAA, CNAME, MX, NAPTR, NS
 API
 ===
 
-The API is pretty simple, three functions are provided in the ``DNSResolver`` class:
+The API is pretty simple, the following functions are provided in the ``DNSResolver`` class:
 
 * ``query(host, type)``: Do a DNS resolution of the given type for the given hostname. It returns an
   instance of ``asyncio.Future``. The actual result of the DNS query is taken directly from pycares.
@@ -53,6 +53,27 @@ The API is pretty simple, three functions are provided in the ``DNSResolver`` cl
 * ``gethostbyaddr(name)``: Make a reverse lookup for an address.
 * ``cancel()``: Cancel all pending DNS queries. All futures will get ``DNSError`` exception set, with
   ``ARES_ECANCELLED`` errno.
+* ``close()``: Close the resolver. This releases all resources and cancels any pending queries. It must be called
+  when the resolver is no longer needed (e.g., application shutdown). The resolver should only be closed from the
+  event loop that created the resolver.
+
+
+Async Context Manager Support
+=============================
+
+While not recommended for typical use cases, ``DNSResolver`` can be used as an async context manager
+for scenarios where automatic cleanup is desired:
+
+.. code:: python
+
+    async with aiodns.DNSResolver() as resolver:
+        result = await resolver.query('example.com', 'A')
+        # resolver.close() is called automatically when exiting the context
+
+**Important**: This pattern is discouraged for most applications because ``DNSResolver`` instances
+are designed to be long-lived and reused for many queries. Creating and destroying resolvers
+frequently adds unnecessary overhead. Use the context manager pattern only when you specifically
+need automatic cleanup for short-lived resolver instances, such as in tests or one-off scripts.
 
 
 Note for Windows users

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -e .
-pycares==4.8.0
+pycares==4.9.0
 pytest==8.4.0
 pytest-asyncio==0.26.0
 pytest-cov==6.2.1

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     license='MIT',
     long_description=codecs.open('README.rst', encoding='utf-8').read(),
     long_description_content_type='text/x-rst',
-    install_requires=['pycares>=4.0.0'],
+    install_requires=['pycares>=4.9.0'],
     packages=['aiodns'],
     package_data={'aiodns': ['py.typed']},
     platforms=['POSIX', 'Microsoft Windows'],

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -9,7 +9,6 @@ import sys
 import time
 import unittest
 import unittest.mock
-import warnings
 from typing import Any
 
 import pycares
@@ -638,23 +637,26 @@ def test_del_with_stopped_event_loop() -> None:
     # Create resolver with this loop
     resolver = aiodns.DNSResolver(loop=loop)
 
+    # Track if cleanup was called
+    cleanup_called = False
+    original_cleanup = resolver._cleanup
+
+    def mock_cleanup():
+        nonlocal cleanup_called
+        cleanup_called = True
+        original_cleanup()
+
+    resolver._cleanup = mock_cleanup
+
     # Close the loop so it's not running
     loop.close()
 
-    # Capture warnings
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always', ResourceWarning)
+    # Delete resolver when its loop is not running
+    del resolver
+    gc.collect()
 
-        # Delete resolver when its loop is not running
-        del resolver
-        gc.collect()
-
-        # Should have a ResourceWarning
-        assert len(w) == 1
-        assert 'DNSResolver was garbage collected without being closed' in str(
-            w[0].message
-        )
-        assert w[0].category is ResourceWarning
+    # Should have called cleanup
+    assert cleanup_called
 
 
 @pytest.mark.asyncio

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -786,10 +786,10 @@ async def test_context_manager_close_idempotent() -> None:
             close_count += 1
             await original_close()
 
-        resolver.close = mock_close
+        resolver.close = mock_close  # type: ignore[method-assign]
 
         # Manually close resolver within context
-        await resolver.close()  # type: ignore[no-untyped-call]
+        await resolver.close()
         assert close_count == 1
 
     # Context manager should call close again, but it should be idempotent

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -243,7 +243,7 @@ class TestQueryTimeout(DNSTest):
         self.loop = asyncio.new_event_loop()
         self.addCleanup(self.loop.close)
         self.resolver = aiodns.DNSResolver(
-            timeout=0.1, tries=1, loop=self.loop
+            timeout=0.000001, tries=1, loop=self.loop
         )
         self.resolver.nameservers = ['1.2.3.4']
 
@@ -300,7 +300,7 @@ class TestUV_QueryTimeout(TestQueryTimeout):
         self.loop = asyncio.new_event_loop()
         self.addCleanup(self.loop.close)
         self.resolver = aiodns.DNSResolver(
-            timeout=0.1, tries=1, loop=self.loop
+            timeout=0.000001, tries=1, loop=self.loop
         )
         self.resolver.nameservers = ['1.2.3.4']
 

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -435,7 +435,8 @@ async def test_make_channel_ares_error(
         for part in unexpected_msg_parts:
             assert part not in caplog.text
 
-        # Manually set _closed to True to prevent cleanup logic from running during the test.
+        # Manually set _closed to True to prevent cleanup logic from
+        # running during the test.
         resolver._closed = True
 
 

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -432,7 +432,7 @@ async def test_make_channel_ares_error(
         for part in unexpected_msg_parts:
             assert part not in caplog.text
 
-        resolver._closed = True  # type: ignore[assignment]
+        resolver._closed = True
 
 
 def test_win32_import_winloop_error() -> None:
@@ -613,12 +613,12 @@ def test_del_with_no_running_loop() -> None:
     cleanup_called = False
     original_close = resolver._channel.close
 
-    def mock_close():
+    def mock_close() -> None:
         nonlocal cleanup_called
         cleanup_called = True
         original_close()
 
-    resolver._channel.close = mock_close
+    resolver._channel.close = mock_close  # type: ignore[method-assign]
     loop.close()
 
     # Delete the resolver without closing it
@@ -699,8 +699,8 @@ async def test_cleanup_method() -> None:
     resolver._timer = mock_timer
 
     # Mock loop methods
-    resolver.loop.remove_reader = unittest.mock.MagicMock()
-    resolver.loop.remove_writer = unittest.mock.MagicMock()
+    resolver.loop.remove_reader = unittest.mock.MagicMock()  # type: ignore[method-assign]
+    resolver.loop.remove_writer = unittest.mock.MagicMock()  # type: ignore[method-assign]
 
     # Call cleanup
     resolver._cleanup()
@@ -710,10 +710,10 @@ async def test_cleanup_method() -> None:
     assert resolver._timer is None
 
     # Verify file descriptors were removed
-    resolver.loop.remove_reader.assert_any_call(1)
-    resolver.loop.remove_reader.assert_any_call(2)
-    resolver.loop.remove_writer.assert_any_call(3)
-    resolver.loop.remove_writer.assert_any_call(4)
+    resolver.loop.remove_reader.assert_any_call(1)  # type: ignore[attr-defined]
+    resolver.loop.remove_reader.assert_any_call(2)  # type: ignore[attr-defined]
+    resolver.loop.remove_writer.assert_any_call(3)  # type: ignore[attr-defined]
+    resolver.loop.remove_writer.assert_any_call(4)  # type: ignore[attr-defined]
 
     # Verify sets are cleared
     assert len(resolver._read_fds) == 0
@@ -733,12 +733,12 @@ async def test_context_manager() -> None:
         # Mock the close method to track if it's called
         original_close = resolver.close
 
-        async def mock_close():
+        async def mock_close() -> None:
             nonlocal resolver_closed
             resolver_closed = True
             await original_close()
 
-        resolver.close = mock_close
+        resolver.close = mock_close  # type: ignore[method-assign]
 
         # Resolver should be usable within context
         assert isinstance(resolver, aiodns.DNSResolver)

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -243,7 +243,7 @@ class TestQueryTimeout(unittest.TestCase):
         self.loop = asyncio.new_event_loop()
         self.addCleanup(self.loop.close)
         self.resolver = aiodns.DNSResolver(
-            timeout=0.000001, tries=1, loop=self.loop
+            timeout=0.01, tries=1, loop=self.loop
         )
         self.resolver.nameservers = ['1.2.3.4']
 

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -232,7 +232,7 @@ class TestQueryTxtChaos(DNSTest):
         self.assertTrue(result)
 
 
-class TestQueryTimeout(DNSTest):
+class TestQueryTimeout(unittest.TestCase):
     """Test DNS queries with timeout configuration."""
 
     def setUp(self) -> None:
@@ -246,6 +246,11 @@ class TestQueryTimeout(DNSTest):
             timeout=0.000001, tries=1, loop=self.loop
         )
         self.resolver.nameservers = ['1.2.3.4']
+
+    def tearDown(self) -> None:
+        if self.resolver is not None:
+            self.loop.run_until_complete(self.resolver.close())
+        self.resolver = None  # type: ignore[assignment]
 
     def test_query_timeout(self) -> None:
         f = self.resolver.query('google.com', 'A')

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -710,7 +710,7 @@ async def test_cleanup_method() -> None:
     assert resolver._timer is None
 
     # Verify file descriptors were removed
-    resolver.loop.remove_reader.assert_any_call(1)
+    resolver.loop.remove_reader.assert_any_call(1)  # type: ignore[unreachable]
     resolver.loop.remove_reader.assert_any_call(2)
     resolver.loop.remove_writer.assert_any_call(3)
     resolver.loop.remove_writer.assert_any_call(4)

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -609,16 +609,16 @@ def test_del_with_no_running_loop() -> None:
     loop = asyncio.new_event_loop()
     resolver = aiodns.DNSResolver(loop=loop)
 
-    # Track if cleanup was called
+    # Track if cleanup was called via channel.close
     cleanup_called = False
-    original_cleanup = resolver._cleanup
+    original_close = resolver._channel.close
 
-    def mock_cleanup():
+    def mock_close():
         nonlocal cleanup_called
         cleanup_called = True
-        original_cleanup()
+        original_close()
 
-    resolver._cleanup = mock_cleanup
+    resolver._channel.close = mock_close
     loop.close()
 
     # Delete the resolver without closing it

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -41,8 +41,7 @@ class DNSTest(unittest.TestCase):
         self.resolver.nameservers = ['8.8.8.8']
 
     def tearDown(self) -> None:
-        if self.resolver is not None:
-            self.loop.run_until_complete(self.resolver.close())
+        self.loop.run_until_complete(self.resolver.close())
         self.resolver = None  # type: ignore[assignment]
 
     def test_query_a(self) -> None:
@@ -248,8 +247,7 @@ class TestQueryTimeout(unittest.TestCase):
         self.resolver.nameservers = ['1.2.3.4']
 
     def tearDown(self) -> None:
-        if self.resolver is not None:
-            self.loop.run_until_complete(self.resolver.close())
+        self.loop.run_until_complete(self.resolver.close())
         self.resolver = None  # type: ignore[assignment]
 
     def test_query_timeout(self) -> None:

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -668,12 +668,12 @@ async def test_del_with_running_event_loop() -> None:
     original_close = resolver._channel.close
     cleanup_called = False
 
-    def mock_close():
+    def mock_close() -> None:
         nonlocal cleanup_called
         cleanup_called = True
         original_close()
 
-    resolver._channel.close = mock_close
+    resolver._channel.close = mock_close  # type: ignore[method-assign]
 
     # Delete resolver while loop is running
     del resolver
@@ -710,10 +710,10 @@ async def test_cleanup_method() -> None:
     assert resolver._timer is None
 
     # Verify file descriptors were removed
-    resolver.loop.remove_reader.assert_any_call(1)  # type: ignore[attr-defined]
-    resolver.loop.remove_reader.assert_any_call(2)  # type: ignore[attr-defined]
-    resolver.loop.remove_writer.assert_any_call(3)  # type: ignore[attr-defined]
-    resolver.loop.remove_writer.assert_any_call(4)  # type: ignore[attr-defined]
+    resolver.loop.remove_reader.assert_any_call(1)
+    resolver.loop.remove_reader.assert_any_call(2)
+    resolver.loop.remove_writer.assert_any_call(3)
+    resolver.loop.remove_writer.assert_any_call(4)
 
     # Verify sets are cleared
     assert len(resolver._read_fds) == 0
@@ -757,12 +757,12 @@ async def test_context_manager_with_exception() -> None:
             # Mock the close method to track if it's called
             original_close = resolver.close
 
-            async def mock_close():
+            async def mock_close() -> None:
                 nonlocal resolver_closed
                 resolver_closed = True
                 await original_close()
 
-            resolver.close = mock_close
+            resolver.close = mock_close  # type: ignore[method-assign]
 
             # Raise an exception within the context
             raise ValueError('Test exception')
@@ -781,7 +781,7 @@ async def test_context_manager_close_idempotent() -> None:
     async with aiodns.DNSResolver() as resolver:
         original_close = resolver.close
 
-        async def mock_close():
+        async def mock_close() -> None:
             nonlocal close_count
             close_count += 1
             await original_close()

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -641,12 +641,12 @@ def test_del_with_stopped_event_loop() -> None:
     cleanup_called = False
     original_close = resolver._channel.close
 
-    def mock_close():
+    def mock_close() -> None:
         nonlocal cleanup_called
         cleanup_called = True
         original_close()
 
-    resolver._channel.close = mock_close
+    resolver._channel.close = mock_close  # type: ignore[method-assign]
 
     # Close the loop so it's not running
     loop.close()

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -435,6 +435,7 @@ async def test_make_channel_ares_error(
         for part in unexpected_msg_parts:
             assert part not in caplog.text
 
+        # Manually set _closed to True to prevent cleanup logic from running during the test.
         resolver._closed = True
 
 

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -637,16 +637,16 @@ def test_del_with_stopped_event_loop() -> None:
     # Create resolver with this loop
     resolver = aiodns.DNSResolver(loop=loop)
 
-    # Track if cleanup was called
+    # Track if cleanup was called via channel.close
     cleanup_called = False
-    original_cleanup = resolver._cleanup
+    original_close = resolver._channel.close
 
-    def mock_cleanup():
+    def mock_close():
         nonlocal cleanup_called
         cleanup_called = True
-        original_cleanup()
+        original_close()
 
-    resolver._cleanup = mock_cleanup
+    resolver._channel.close = mock_close
 
     # Close the loop so it's not running
     loop.close()

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import asyncio
+import gc
 import ipaddress
 import logging
 import socket
@@ -8,6 +9,7 @@ import sys
 import time
 import unittest
 import unittest.mock
+import warnings
 from typing import Any
 
 import pycares
@@ -40,6 +42,8 @@ class DNSTest(unittest.TestCase):
         self.resolver.nameservers = ['8.8.8.8']
 
     def tearDown(self) -> None:
+        if self.resolver is not None:
+            self.loop.run_until_complete(self.resolver.close())
         self.resolver = None  # type: ignore[assignment]
 
     def test_query_a(self) -> None:
@@ -114,32 +118,10 @@ class DNSTest(unittest.TestCase):
     def test_query_bad_type(self) -> None:
         self.assertRaises(ValueError, self.resolver.query, 'google.com', 'XXX')
 
-    def test_query_txt_chaos(self) -> None:
-        self.resolver = aiodns.DNSResolver(loop=self.loop)
-        self.resolver.nameservers = ['1.1.1.1']
-        f = self.resolver.query('id.server', 'TXT', 'CHAOS')
-        result = self.loop.run_until_complete(f)
-        self.assertTrue(result)
-
     def test_query_bad_class(self) -> None:
         self.assertRaises(
             ValueError, self.resolver.query, 'google.com', 'A', 'INVALIDCLASS'
         )
-
-    def test_query_timeout(self) -> None:
-        self.resolver = aiodns.DNSResolver(
-            timeout=0.1, tries=1, loop=self.loop
-        )
-        self.resolver.nameservers = ['1.2.3.4']
-        f = self.resolver.query('google.com', 'A')
-        started = time.monotonic()
-        try:
-            self.loop.run_until_complete(f)
-        except aiodns.error.DNSError as e:
-            self.assertEqual(e.args[0], aiodns.error.ARES_ETIMEOUT)
-        # Ensure timeout really cuts time deadline.
-        # Limit duration to one second
-        self.assertLess(time.monotonic() - started, 1)
 
     def test_query_cancel(self) -> None:
         f = self.resolver.query('google.com', 'A')
@@ -232,6 +214,52 @@ class DNSTest(unittest.TestCase):
 #        self.assertTrue(result)
 
 
+class TestQueryTxtChaos(DNSTest):
+    """Test DNS queries with CHAOS class."""
+
+    def setUp(self) -> None:
+        if sys.platform == 'win32':
+            asyncio.set_event_loop_policy(
+                asyncio.WindowsSelectorEventLoopPolicy()
+            )
+        self.loop = asyncio.new_event_loop()
+        self.addCleanup(self.loop.close)
+        self.resolver = aiodns.DNSResolver(loop=self.loop)
+        self.resolver.nameservers = ['1.1.1.1']
+
+    def test_query_txt_chaos(self) -> None:
+        f = self.resolver.query('id.server', 'TXT', 'CHAOS')
+        result = self.loop.run_until_complete(f)
+        self.assertTrue(result)
+
+
+class TestQueryTimeout(DNSTest):
+    """Test DNS queries with timeout configuration."""
+
+    def setUp(self) -> None:
+        if sys.platform == 'win32':
+            asyncio.set_event_loop_policy(
+                asyncio.WindowsSelectorEventLoopPolicy()
+            )
+        self.loop = asyncio.new_event_loop()
+        self.addCleanup(self.loop.close)
+        self.resolver = aiodns.DNSResolver(
+            timeout=0.1, tries=1, loop=self.loop
+        )
+        self.resolver.nameservers = ['1.2.3.4']
+
+    def test_query_timeout(self) -> None:
+        f = self.resolver.query('google.com', 'A')
+        started = time.monotonic()
+        try:
+            self.loop.run_until_complete(f)
+        except aiodns.error.DNSError as e:
+            self.assertEqual(e.args[0], aiodns.error.ARES_ETIMEOUT)
+        # Ensure timeout really cuts time deadline.
+        # Limit duration to one second
+        self.assertLess(time.monotonic() - started, 1)
+
+
 @unittest.skipIf(skip_uvloop, "We don't have a uvloop or winloop module")
 class TestUV_DNS(DNSTest):
     def setUp(self) -> None:
@@ -244,6 +272,52 @@ class TestUV_DNS(DNSTest):
 
 class TestNoEventThreadDNS(DNSTest):
     """Test DNSResolver with no event thread."""
+
+    def setUp(self) -> None:
+        with unittest.mock.patch(
+            'aiodns.pycares.ares_threadsafety', return_value=False
+        ):
+            super().setUp()
+
+
+@unittest.skipIf(skip_uvloop, "We don't have a uvloop or winloop module")
+class TestUV_QueryTxtChaos(TestQueryTxtChaos):
+    """Test DNS queries with CHAOS class using uvloop."""
+
+    def setUp(self) -> None:
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+        self.loop = asyncio.new_event_loop()
+        self.addCleanup(self.loop.close)
+        self.resolver = aiodns.DNSResolver(loop=self.loop)
+        self.resolver.nameservers = ['1.1.1.1']
+
+
+@unittest.skipIf(skip_uvloop, "We don't have a uvloop or winloop module")
+class TestUV_QueryTimeout(TestQueryTimeout):
+    """Test DNS queries with timeout configuration using uvloop."""
+
+    def setUp(self) -> None:
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+        self.loop = asyncio.new_event_loop()
+        self.addCleanup(self.loop.close)
+        self.resolver = aiodns.DNSResolver(
+            timeout=0.1, tries=1, loop=self.loop
+        )
+        self.resolver.nameservers = ['1.2.3.4']
+
+
+class TestNoEventThreadQueryTxtChaos(TestQueryTxtChaos):
+    """Test DNS queries with CHAOS class without event thread."""
+
+    def setUp(self) -> None:
+        with unittest.mock.patch(
+            'aiodns.pycares.ares_threadsafety', return_value=False
+        ):
+            super().setUp()
+
+
+class TestNoEventThreadQueryTimeout(TestQueryTimeout):
+    """Test DNS queries with timeout configuration without event thread."""
 
     def setUp(self) -> None:
         with unittest.mock.patch(
@@ -358,6 +432,8 @@ async def test_make_channel_ares_error(
         # Check unexpected message parts aren't in the captured log
         for part in unexpected_msg_parts:
             assert part not in caplog.text
+
+        resolver._closed = True  # type: ignore[assignment]
 
 
 def test_win32_import_winloop_error() -> None:
@@ -486,6 +562,232 @@ def test_win32_winloop_loop_instance() -> None:
         # This should not raise an exception since loop
         # is a winloop.Loop instance
         aiodns.DNSResolver(loop=mock_loop)
+
+
+@pytest.mark.asyncio
+async def test_close_resolver() -> None:
+    """Test that DNSResolver.close() properly shuts down the resolver."""
+    resolver = aiodns.DNSResolver()
+
+    # Create a query to ensure resolver is active
+    query_future = resolver.query('google.com', 'A')
+
+    # Close the resolver
+    await resolver.close()
+
+    # Verify resolver is marked as closed
+    assert resolver._closed
+
+    # Verify timers are cancelled
+    assert resolver._timer is None
+
+    # Verify file descriptors are cleared
+    assert len(resolver._read_fds) == 0
+    assert len(resolver._write_fds) == 0
+
+    # The query should fail with cancellation
+    with pytest.raises(aiodns.error.DNSError) as exc_info:
+        await query_future
+    assert exc_info.value.args[0] == aiodns.error.ARES_ECANCELLED
+
+
+@pytest.mark.asyncio
+async def test_close_resolver_multiple_times() -> None:
+    """Test that close() is idempotent and safe to call multiple times."""
+    resolver = aiodns.DNSResolver()
+
+    # Close multiple times
+    await resolver.close()
+    await resolver.close()
+    await resolver.close()
+
+    # All closes should succeed without error
+    assert resolver._closed
+
+
+def test_del_with_no_running_loop() -> None:
+    """Test __del__ when there's no running event loop."""
+    loop = asyncio.new_event_loop()
+    resolver = aiodns.DNSResolver(loop=loop)
+    loop.close()
+
+    # Capture warnings
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always', ResourceWarning)
+
+        # Delete the resolver without closing it
+        del resolver
+        gc.collect()
+
+        # Should have a ResourceWarning
+        assert 'DNSResolver was garbage collected without being closed' in str(
+            w[0].message
+        )
+        assert w[0].category is ResourceWarning
+
+
+def test_del_with_stopped_event_loop() -> None:
+    """Test __del__ when event loop is not running."""
+    # Create a new event loop
+    loop = asyncio.new_event_loop()
+
+    # Create resolver with this loop
+    resolver = aiodns.DNSResolver(loop=loop)
+
+    # Close the loop so it's not running
+    loop.close()
+
+    # Capture warnings
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always', ResourceWarning)
+
+        # Delete resolver when its loop is not running
+        del resolver
+        gc.collect()
+
+        # Should have a ResourceWarning
+        assert len(w) == 1
+        assert 'DNSResolver was garbage collected without being closed' in str(
+            w[0].message
+        )
+        assert w[0].category is ResourceWarning
+
+
+@pytest.mark.asyncio
+async def test_del_with_running_event_loop() -> None:
+    """Test __del__ when event loop is running performs cleanup."""
+    resolver = aiodns.DNSResolver()
+
+    # Mark that cleanup was called by checking if channel.close was called
+    original_close = resolver._channel.close
+    cleanup_called = False
+
+    def mock_close():
+        nonlocal cleanup_called
+        cleanup_called = True
+        original_close()
+
+    resolver._channel.close = mock_close
+
+    # Delete resolver while loop is running
+    del resolver
+    gc.collect()
+
+    # Verify cleanup was called
+    assert cleanup_called
+
+
+@pytest.mark.asyncio
+async def test_cleanup_method() -> None:
+    """Test that _cleanup() properly cleans up resources."""
+    resolver = aiodns.DNSResolver()
+
+    # Mock file descriptors and timer
+    resolver._read_fds.add(1)
+    resolver._read_fds.add(2)
+    resolver._write_fds.add(3)
+    resolver._write_fds.add(4)
+
+    # Mock timer
+    mock_timer = unittest.mock.MagicMock()
+    resolver._timer = mock_timer
+
+    # Mock loop methods
+    resolver.loop.remove_reader = unittest.mock.MagicMock()
+    resolver.loop.remove_writer = unittest.mock.MagicMock()
+
+    # Call cleanup
+    resolver._cleanup()
+
+    # Verify timer was cancelled
+    mock_timer.cancel.assert_called_once()
+    assert resolver._timer is None
+
+    # Verify file descriptors were removed
+    resolver.loop.remove_reader.assert_any_call(1)
+    resolver.loop.remove_reader.assert_any_call(2)
+    resolver.loop.remove_writer.assert_any_call(3)
+    resolver.loop.remove_writer.assert_any_call(4)
+
+    # Verify sets are cleared
+    assert len(resolver._read_fds) == 0
+    assert len(resolver._write_fds) == 0
+
+
+@pytest.mark.asyncio
+async def test_context_manager() -> None:
+    """Test DNSResolver as async context manager."""
+    resolver_closed = False
+
+    # Create resolver and use as context manager
+    async with aiodns.DNSResolver() as resolver:
+        # Check resolver is not closed
+        assert not resolver._closed
+
+        # Mock the close method to track if it's called
+        original_close = resolver.close
+
+        async def mock_close():
+            nonlocal resolver_closed
+            resolver_closed = True
+            await original_close()
+
+        resolver.close = mock_close
+
+        # Resolver should be usable within context
+        assert isinstance(resolver, aiodns.DNSResolver)
+
+    # After exiting context, close should have been called
+    assert resolver_closed
+
+
+@pytest.mark.asyncio
+async def test_context_manager_with_exception() -> None:
+    """Test DNSResolver context manager handles exceptions properly."""
+    resolver_closed = False
+
+    try:
+        async with aiodns.DNSResolver() as resolver:
+            # Mock the close method to track if it's called
+            original_close = resolver.close
+
+            async def mock_close():
+                nonlocal resolver_closed
+                resolver_closed = True
+                await original_close()
+
+            resolver.close = mock_close
+
+            # Raise an exception within the context
+            raise ValueError('Test exception')
+    except ValueError:
+        pass  # Expected
+
+    # Close should still be called even with exception
+    assert resolver_closed
+
+
+@pytest.mark.asyncio
+async def test_context_manager_close_idempotent() -> None:
+    """Test that close() can be called multiple times safely."""
+    close_count = 0
+
+    async with aiodns.DNSResolver() as resolver:
+        original_close = resolver.close
+
+        async def mock_close():
+            nonlocal close_count
+            close_count += 1
+            await original_close()
+
+        resolver.close = mock_close
+
+        # Manually close resolver within context
+        await resolver.close()
+        assert close_count == 1
+
+    # Context manager should call close again, but it should be idempotent
+    assert close_count == 2
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -305,7 +305,7 @@ class TestUV_QueryTimeout(TestQueryTimeout):
         self.loop = asyncio.new_event_loop()
         self.addCleanup(self.loop.close)
         self.resolver = aiodns.DNSResolver(
-            timeout=0.000001, tries=1, loop=self.loop
+            timeout=0.1, tries=1, loop=self.loop
         )
         self.resolver.nameservers = ['1.2.3.4']
 

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -789,7 +789,7 @@ async def test_context_manager_close_idempotent() -> None:
         resolver.close = mock_close
 
         # Manually close resolver within context
-        await resolver.close()
+        await resolver.close()  # type: ignore[no-untyped-call]
         assert close_count == 1
 
     # Context manager should call close again, but it should be idempotent

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -243,7 +243,7 @@ class TestQueryTimeout(unittest.TestCase):
         self.loop = asyncio.new_event_loop()
         self.addCleanup(self.loop.close)
         self.resolver = aiodns.DNSResolver(
-            timeout=0.01, tries=1, loop=self.loop
+            timeout=0.1, tries=1, loop=self.loop
         )
         self.resolver.nameservers = ['1.2.3.4']
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This PR adds a `close()` method to the `DNSResolver` class to allow for explicit cleanup of resources. The implementation includes:

- New `close()` method that cleanly shuts down the resolver by canceling timers, removing file descriptors, and closing the pycares channel
- Async context manager support (`__aenter__` and `__aexit__`) for automatic cleanup when using `async with`
- Improved `__del__` method that automatically calls cleanup when the resolver is garbage collected
- Comprehensive test coverage for all new functionality

## Are there changes in behavior for the user?

- **New feature**: Users can now explicitly close resolvers with `await resolver.close()`
- **New feature**: Resolvers can be used as async context managers: `async with aiodns.DNSResolver() as resolver:`
- **Improved cleanup**: Resolvers will automatically clean up resources when garbage collected (though explicit cleanup is still recommended)
- **No breaking changes**: All existing functionality remains unchanged

## Related issue number

Fixes #165

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes