### PR TITLE
build: prevent incompatible pycares versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     license='MIT',
     long_description=codecs.open('README.rst', encoding='utf-8').read(),
     long_description_content_type='text/x-rst',
-    install_requires=['pycares>=4.9.0'],
+    install_requires=['pycares>=4.9.0,<5'],
     packages=['aiodns'],
     package_data={'aiodns': ['py.typed']},
     platforms=['POSIX', 'Microsoft Windows'],


### PR DESCRIPTION
Fixes: https://github.com/aio-libs/aiodns/issues/214

It is more reasonable to prevent major version updates.

- [X] I think the code is well written
- [ ] Unit tests for the changes exist  # irrelevant
- [ ] Documentation reflects the changes  # irrelevant
