### PR TITLE
Release 4.0.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,19 @@
+4.0.0
+=====
+- **Breaking change**: Requires pycares >= 5.0.0
+- Added new ``query_dns()`` method returning native pycares 5.x ``DNSResult`` types
+- Deprecated ``query()`` method - still works with backward-compatible result types
+- Deprecated ``gethostbyname()`` method - use ``getaddrinfo()`` instead
+- Added compatibility layer for pycares 4.x result types to ease migration
+- Updated dependencies
+  - Bumped pycares from 4.11.0 to 5.0.1 (#220)
+  - Bumped pytest from 8.4.2 to 9.0.2 (#224)
+  - Bumped pytest-asyncio from 1.2.0 to 1.3.0 (#223)
+  - Bumped mypy from 1.19.0 to 1.19.1 (#219)
+  - Bumped winloop from 0.3.1 to 0.4.0 (#210)
+  - Bumped actions/upload-artifact from 5 to 6 (#222)
+  - Bumped actions/download-artifact from 6.0.0 to 7.0.0 (#221)
+
 3.6.1
 =====
 - Pin pycares to < 5


### PR DESCRIPTION
- **Breaking change**: Requires pycares >= 5.0.0
- Added new `query_dns()` method returning native pycares 5.x `DNSResult` types
- Deprecated `query()` method - still works with backward-compatible result types
- Deprecated `gethostbyname()` method - use `getaddrinfo()` instead
- Added compatibility layer for pycares 4.x result types to ease migration
- Updated dependencies
  - Bumped pycares from 4.11.0 to 5.0.1 (#220)
  - Bumped pytest from 8.4.2 to 9.0.2 (#224)
  - Bumped pytest-asyncio from 1.2.0 to 1.3.0 (#223)
  - Bumped mypy from 1.19.0 to 1.19.1 (#219)
  - Bumped winloop from 0.3.1 to 0.4.0 (#210)
  - Bumped actions/upload-artifact from 5 to 6 (#222)
  - Bumped actions/download-artifact from 6.0.0 to 7.0.0 (#221)