### PR TITLE
Route synchronous pycares AresError through the returned future

### DIFF
--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -219,7 +219,7 @@ class DNSResolver:
         return future, cb
 
     @contextlib.contextmanager
-    def _capture_ares_error(self, fut: asyncio.Future[Any]) -> Iterator[None]:
+    def _capture_ares_error(self, fut: asyncio.Future[_T]) -> Iterator[None]:
         # When pycares raises synchronously (e.g. ARES_EBADNAME for a
         # malformed hostname), c-ares may also invoke the callback first,
         # leaving the future already done. Route the error through the

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -159,6 +159,9 @@ class DNSResolver:
     def _callback(
         self, fut: asyncio.Future[_T], result: _T, errorno: int | None
     ) -> None:
+        # The future can already be done if pycares raised synchronously
+        # and _capture_ares_error set the exception before c-ares delivered
+        # the same error through this callback.
         if fut.done():
             return
         if errorno is not None:
@@ -192,6 +195,7 @@ class DNSResolver:
         errorno: int | None,
     ) -> None:
         """Callback for query that converts results to compatible format."""
+        # See _callback for why we guard on done() rather than cancelled().
         if fut.done():
             return
         if errorno is not None:
@@ -227,9 +231,12 @@ class DNSResolver:
         try:
             yield
         except pycares.AresError as exc:
-            if fut.done() or not exc.args:
+            if fut.done():
                 return
-            errno = exc.args[0]
+            # pycares always raises (errno, message), but be defensive:
+            # an args-less AresError should still resolve the future to
+            # avoid an indefinite hang on `await`.
+            errno = exc.args[0] if exc.args else error.ARES_EFORMERR
             fut.set_exception(
                 error.DNSError(errno, pycares.errno.strerror(errno))
             )
@@ -343,6 +350,7 @@ class DNSResolver:
         errorno: int | None,
     ) -> None:
         """Callback for gethostbyname that converts AddrInfoResult."""
+        # See _callback for why we guard on done() rather than cancelled().
         if fut.done():
             return
         if errorno is not None:

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -227,11 +227,12 @@ class DNSResolver:
         try:
             yield
         except pycares.AresError as exc:
-            if fut.done():
+            if fut.done() or not exc.args:
                 return
             errno = exc.args[0]
-            message = exc.args[1] if len(exc.args) > 1 else ''
-            fut.set_exception(error.DNSError(errno, message))
+            fut.set_exception(
+                error.DNSError(errno, pycares.errno.strerror(errno))
+            )
 
     @overload
     def query(

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import functools
 import logging
 import socket
 import sys
 import warnings
 import weakref
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 
@@ -158,7 +159,7 @@ class DNSResolver:
     def _callback(
         self, fut: asyncio.Future[_T], result: _T, errorno: int | None
     ) -> None:
-        if fut.cancelled():
+        if fut.done():
             return
         if errorno is not None:
             fut.set_exception(
@@ -191,7 +192,7 @@ class DNSResolver:
         errorno: int | None,
     ) -> None:
         """Callback for query that converts results to compatible format."""
-        if fut.cancelled():
+        if fut.done():
             return
         if errorno is not None:
             fut.set_exception(
@@ -216,6 +217,21 @@ class DNSResolver:
         else:
             cb = functools.partial(self._query_callback, future, qtype)
         return future, cb
+
+    @contextlib.contextmanager
+    def _capture_ares_error(self, fut: asyncio.Future[Any]) -> Iterator[None]:
+        # When pycares raises synchronously (e.g. ARES_EBADNAME for a
+        # malformed hostname), c-ares may also invoke the callback first,
+        # leaving the future already done. Route the error through the
+        # future so callers can rely on `await` to raise.
+        try:
+            yield
+        except pycares.AresError as exc:
+            if fut.done():
+                return
+            errno = exc.args[0]
+            message = exc.args[1] if len(exc.args) > 1 else ''
+            fut.set_exception(error.DNSError(errno, message))
 
     @overload
     def query(
@@ -283,12 +299,13 @@ class DNSResolver:
                 raise ValueError(f'invalid query class: {qclass}') from e
 
         fut, cb = self._get_query_future_callback(qtype_int)
-        if qclass_int is not None:
-            self._channel.query(
-                host, qtype_int, query_class=qclass_int, callback=cb
-            )
-        else:
-            self._channel.query(host, qtype_int, callback=cb)
+        with self._capture_ares_error(fut):
+            if qclass_int is not None:
+                self._channel.query(
+                    host, qtype_int, query_class=qclass_int, callback=cb
+                )
+            else:
+                self._channel.query(host, qtype_int, callback=cb)
         return fut
 
     def query_dns(
@@ -308,12 +325,13 @@ class DNSResolver:
 
         fut: asyncio.Future[pycares.DNSResult]
         fut, cb = self._get_future_callback()
-        if qclass_int is not None:
-            self._channel.query(
-                host, qtype_int, query_class=qclass_int, callback=cb
-            )
-        else:
-            self._channel.query(host, qtype_int, callback=cb)
+        with self._capture_ares_error(fut):
+            if qclass_int is not None:
+                self._channel.query(
+                    host, qtype_int, query_class=qclass_int, callback=cb
+                )
+            else:
+                self._channel.query(host, qtype_int, callback=cb)
         return fut
 
     def _gethostbyname_callback(
@@ -324,7 +342,7 @@ class DNSResolver:
         errorno: int | None,
     ) -> None:
         """Callback for gethostbyname that converts AddrInfoResult."""
-        if fut.cancelled():
+        if fut.done():
             return
         if errorno is not None:
             fut.set_exception(
@@ -365,7 +383,8 @@ class DNSResolver:
             )
         else:
             cb = functools.partial(self._gethostbyname_callback, fut, host)
-        self._channel.getaddrinfo(host, None, family=family, callback=cb)
+        with self._capture_ares_error(fut):
+            self._channel.getaddrinfo(host, None, family=family, callback=cb)
         return fut
 
     def getaddrinfo(
@@ -379,15 +398,16 @@ class DNSResolver:
     ) -> asyncio.Future[pycares.AddrInfoResult]:
         fut: asyncio.Future[pycares.AddrInfoResult]
         fut, cb = self._get_future_callback()
-        self._channel.getaddrinfo(
-            host,
-            port,
-            family=family,
-            type=type,
-            proto=proto,
-            flags=flags,
-            callback=cb,
-        )
+        with self._capture_ares_error(fut):
+            self._channel.getaddrinfo(
+                host,
+                port,
+                family=family,
+                type=type,
+                proto=proto,
+                flags=flags,
+                callback=cb,
+            )
         return fut
 
     def getnameinfo(
@@ -397,13 +417,15 @@ class DNSResolver:
     ) -> asyncio.Future[pycares.NameInfoResult]:
         fut: asyncio.Future[pycares.NameInfoResult]
         fut, cb = self._get_future_callback()
-        self._channel.getnameinfo(sockaddr, flags, callback=cb)
+        with self._capture_ares_error(fut):
+            self._channel.getnameinfo(sockaddr, flags, callback=cb)
         return fut
 
     def gethostbyaddr(self, name: str) -> asyncio.Future[pycares.HostResult]:
         fut: asyncio.Future[pycares.HostResult]
         fut, cb = self._get_future_callback()
-        self._channel.gethostbyaddr(name, callback=cb)
+        with self._capture_ares_error(fut):
+            self._channel.gethostbyaddr(name, callback=cb)
         return fut
 
     def cancel(self) -> None:

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -1438,9 +1438,8 @@ def _call_resolver_entry_point(
         return resolver.getaddrinfo('host')
     if channel_method == 'getnameinfo':
         return resolver.getnameinfo(('127.0.0.1', 0))
-    if channel_method == 'gethostbyaddr':
-        return resolver.gethostbyaddr('127.0.0.1')
-    raise AssertionError(f'unknown entry point: {channel_method}')
+    assert channel_method == 'gethostbyaddr'
+    return resolver.gethostbyaddr('127.0.0.1')
 
 
 @pytest.mark.asyncio

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -1398,49 +1398,54 @@ async def test_query_callback_error() -> None:
     resolver._closed = True
 
 
-@pytest.mark.asyncio
-async def test_query_dns_malformed_name_returns_future() -> None:
-    """A synchronous pycares.AresError must be routed through the future.
+async def _assert_malformed_name_routes_through_future(
+    fut: asyncio.Future[Any],
+) -> None:
+    assert isinstance(fut, asyncio.Future)
+    with pytest.raises(aiodns.error.DNSError) as exc_info:
+        await fut
+    assert exc_info.value.args[0] == aiodns.error.ARES_EBADNAME
 
-    Regression test for https://github.com/aio-libs/aiodns/issues/231.
-    Previously, a malformed name caused query_dns() to raise AresError
-    synchronously, leaving the internally-created future orphaned with
-    an unretrieved exception.
+
+@pytest.mark.asyncio
+async def test_query_dns_malformed_name_routes_through_future() -> None:
+    """Synchronous pycares.AresError must be routed through the future.
+
+    Regression test for https://github.com/aio-libs/aiodns/issues/231:
+    previously a malformed name raised AresError synchronously, leaving
+    the internally-created future orphaned with an unretrieved exception.
     """
     async with aiodns.DNSResolver() as resolver:
-        fut = resolver.query_dns('example test.com', 'A')
-        assert isinstance(fut, asyncio.Future)
-        with pytest.raises(aiodns.error.DNSError) as exc_info:
-            await fut
-        assert exc_info.value.args[0] == aiodns.error.ARES_EBADNAME
+        await _assert_malformed_name_routes_through_future(
+            resolver.query_dns('example test.com', 'A')
+        )
 
 
 @pytest.mark.asyncio
-async def test_query_malformed_name_returns_future() -> None:
-    """query() must also route AresError through the future."""
+async def test_query_malformed_name_routes_through_future() -> None:
+    """Same as above for the deprecated query() entry point."""
     async with aiodns.DNSResolver() as resolver:
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', DeprecationWarning)
             fut = resolver.query('example test.com', 'A')
-        assert isinstance(fut, asyncio.Future)
-        with pytest.raises(aiodns.error.DNSError) as exc_info:
-            await fut
-        assert exc_info.value.args[0] == aiodns.error.ARES_EBADNAME
+        await _assert_malformed_name_routes_through_future(fut)
 
 
 @pytest.mark.asyncio
-async def test_query_dns_original_issue_example() -> None:
-    """Verify the exact example from issue #231 outputs only 'Error'."""
-    messages: list[str] = []
-
+async def test_capture_ares_error_leaves_done_future_untouched() -> None:
+    """When the callback already finished the future, the captured
+    AresError must be discarded so the original result is preserved."""
     async with aiodns.DNSResolver() as resolver:
-        try:
-            query = resolver.query_dns('example test.com', 'A')
-            await query
-        except aiodns.error.DNSError:
-            messages.append('Error')
-
-    assert messages == ['Error']
+        fut: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+        fut.set_result(None)
+        exc = pycares.AresError(
+            aiodns.error.ARES_EBADNAME, 'Misformatted domain name'
+        )
+        cm = resolver._capture_ares_error(fut)
+        cm.__enter__()
+        suppressed = cm.__exit__(type(exc), exc, exc.__traceback__)
+        assert suppressed
+        assert fut.result() is None
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -1398,5 +1398,50 @@ async def test_query_callback_error() -> None:
     resolver._closed = True
 
 
+@pytest.mark.asyncio
+async def test_query_dns_malformed_name_returns_future() -> None:
+    """A synchronous pycares.AresError must be routed through the future.
+
+    Regression test for https://github.com/aio-libs/aiodns/issues/231.
+    Previously, a malformed name caused query_dns() to raise AresError
+    synchronously, leaving the internally-created future orphaned with
+    an unretrieved exception.
+    """
+    async with aiodns.DNSResolver() as resolver:
+        fut = resolver.query_dns('example test.com', 'A')
+        assert isinstance(fut, asyncio.Future)
+        with pytest.raises(aiodns.error.DNSError) as exc_info:
+            await fut
+        assert exc_info.value.args[0] == aiodns.error.ARES_EBADNAME
+
+
+@pytest.mark.asyncio
+async def test_query_malformed_name_returns_future() -> None:
+    """query() must also route AresError through the future."""
+    async with aiodns.DNSResolver() as resolver:
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            fut = resolver.query('example test.com', 'A')
+        assert isinstance(fut, asyncio.Future)
+        with pytest.raises(aiodns.error.DNSError) as exc_info:
+            await fut
+        assert exc_info.value.args[0] == aiodns.error.ARES_EBADNAME
+
+
+@pytest.mark.asyncio
+async def test_query_dns_original_issue_example() -> None:
+    """Verify the exact example from issue #231 outputs only 'Error'."""
+    messages: list[str] = []
+
+    async with aiodns.DNSResolver() as resolver:
+        try:
+            query = resolver.query_dns('example test.com', 'A')
+            await query
+        except aiodns.error.DNSError:
+            messages.append('Error')
+
+    assert messages == ['Error']
+
+
 if __name__ == '__main__':  # pragma: no cover
     unittest.main(verbosity=2)

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -1431,6 +1431,42 @@ async def test_query_malformed_name_routes_through_future() -> None:
         await _assert_malformed_name_routes_through_future(fut)
 
 
+def _call_resolver_entry_point(
+    resolver: aiodns.DNSResolver, channel_method: str
+) -> asyncio.Future[Any]:
+    if channel_method == 'getaddrinfo':
+        return resolver.getaddrinfo('host')
+    if channel_method == 'getnameinfo':
+        return resolver.getnameinfo(('127.0.0.1', 0))
+    if channel_method == 'gethostbyaddr':
+        return resolver.gethostbyaddr('127.0.0.1')
+    raise AssertionError(f'unknown entry point: {channel_method}')
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'channel_method', ['getaddrinfo', 'getnameinfo', 'gethostbyaddr']
+)
+async def test_wrapped_entry_points_route_sync_ares_error(
+    channel_method: str,
+) -> None:
+    """Each wrapper routes a synchronous AresError to the returned future.
+
+    pycares does not currently validate inputs to these entry points
+    synchronously, so we inject an AresError via mock to prove the
+    wrapper is wired up and would not regress to a sync raise.
+    """
+    async with aiodns.DNSResolver() as resolver:
+        exc = pycares.AresError(
+            aiodns.error.ARES_EBADNAME, 'Misformatted domain name'
+        )
+        with unittest.mock.patch.object(
+            resolver._channel, channel_method, side_effect=exc
+        ):
+            fut = _call_resolver_entry_point(resolver, channel_method)
+        await _assert_malformed_name_routes_through_future(fut)
+
+
 @pytest.mark.asyncio
 async def test_capture_ares_error_leaves_done_future_untouched() -> None:
     """When the callback already finished the future, the captured

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -1441,10 +1441,15 @@ async def test_capture_ares_error_leaves_done_future_untouched() -> None:
         exc = pycares.AresError(
             aiodns.error.ARES_EBADNAME, 'Misformatted domain name'
         )
-        cm = resolver._capture_ares_error(fut)
-        cm.__enter__()
-        suppressed = cm.__exit__(type(exc), exc, exc.__traceback__)
-        assert suppressed
+        propagated = False
+        try:
+            with resolver._capture_ares_error(fut):
+                raise exc
+        except pycares.AresError:
+            propagated = True
+        assert not propagated, (
+            'context manager should have swallowed AresError'
+        )
         assert fut.result() is None
 
 

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -1434,23 +1434,16 @@ async def test_query_malformed_name_routes_through_future() -> None:
 @pytest.mark.asyncio
 async def test_capture_ares_error_leaves_done_future_untouched() -> None:
     """When the callback already finished the future, the captured
-    AresError must be discarded so the original result is preserved."""
+    AresError must be discarded; reaching the body of the context
+    manager would call set_exception() on a done future and raise
+    InvalidStateError, so passing through cleanly is the assertion."""
     async with aiodns.DNSResolver() as resolver:
         fut: asyncio.Future[None] = asyncio.get_running_loop().create_future()
         fut.set_result(None)
-        exc = pycares.AresError(
-            aiodns.error.ARES_EBADNAME, 'Misformatted domain name'
-        )
-        propagated = False
-        try:
-            with resolver._capture_ares_error(fut):
-                raise exc
-        except pycares.AresError:
-            propagated = True
-        assert not propagated, (
-            'context manager should have swallowed AresError'
-        )
-        assert fut.result() is None
+        with resolver._capture_ares_error(fut):
+            raise pycares.AresError(
+                aiodns.error.ARES_EBADNAME, 'Misformatted domain name'
+            )
 
 
 if __name__ == '__main__':  # pragma: no cover


### PR DESCRIPTION
## Summary

Home Assistant was about to merge a workaround for this so I figured we should fix it here instead https://github.com/home-assistant/core/pull/170048

Fixes #231; query methods could raise `pycares.AresError` synchronously (for example on a malformed hostname), leaving the internally created future orphaned with an unretrieved exception and producing a noisy `Future exception was never retrieved` warning.

Each pycares call is now wrapped in a `_capture_ares_error` context manager that sets the error on the future, so callers can rely on `await` to raise just like for asynchronous c-ares errors.

## Test plan
- [x] New tests in `tests/test_aiodns.py` cover `query`, `query_dns`, and the exact example from the issue
- [x] Full test suite passes locally (89 passed)