### PR TITLE
Document the release process and add scripts/release-notes.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,6 +142,39 @@ Running the test suite
 To run the test suite: ``python -m pytest tests/``
 
 
+Releasing (maintainers only)
+============================
+
+Releases are cut from ``master`` and published to PyPI automatically by the
+``Release Wheels`` workflow when a GitHub Release is created.
+
+1. **Prepare the release PR.** Bump ``__version__`` in ``aiodns/__init__.py``
+   and prepend a section to ``ChangeLog`` describing the user-facing changes
+   since the previous tag, in the same RST style as the existing entries
+   (``X.Y.Z`` header underlined with ``=``). Open the PR with the title
+   ``Release X.Y.Z`` and merge it once CI is green.
+
+2. **Tag and publish the release.** From a clean checkout of ``master`` that
+   includes the merged release PR, generate the release notes from
+   ``ChangeLog`` and create the GitHub release in one shot::
+
+       python scripts/release-notes.py --target X.Y.Z \
+           | gh release create vX.Y.Z --repo aio-libs/aiodns \
+                 --title vX.Y.Z --notes-file -
+
+   The helper script reads ``__version__`` and the topmost ``ChangeLog``
+   section and aborts non-zero if they disagree, or if ``--target`` does
+   not match the current state on disk, so you can't accidentally publish
+   notes for a version the release PR hasn't actually landed yet.
+
+3. **Watch the wheel build.** Publishing the GitHub release fires
+   ``release-wheels.yml``, which builds wheels + sdist and pushes them to
+   `PyPI <https://pypi.org/project/aiodns/>`_ via trusted publishing
+   (no token required). Confirm the run succeeds::
+
+       gh run list --repo aio-libs/aiodns --workflow release-wheels.yml --limit 1
+
+
 Author
 ======
 

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+r"""
+Generate release notes for the current release.
+
+Reads the version from ``aiodns/__init__.py`` and the matching section from
+``ChangeLog``. Fails if they disagree, or if a ``--target`` is supplied and
+does not match the current state on disk.
+
+Run after the "Release X.Y.Z" PR has been merged into master, e.g.::
+
+    python scripts/release-notes.py --target 4.0.1 \\
+        | gh release create v4.0.1 --repo aio-libs/aiodns \\
+              --title v4.0.1 --notes-file -
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+VERSION_RE = re.compile(r"^__version__\s*=\s*['\"]([^'\"]+)['\"]", re.M)
+HEADER_RE = re.compile(r'^(\d+\.\d+\.\d+[a-z0-9.\-]*)\s*\n=+\s*$', re.M)
+
+
+def read_version() -> str:
+    text = (ROOT / 'aiodns' / '__init__.py').read_text()
+    match = VERSION_RE.search(text)
+    if not match:
+        sys.exit('could not find __version__ in aiodns/__init__.py')
+    return match.group(1)
+
+
+def read_top_changelog_section() -> tuple[str, str]:
+    text = (ROOT / 'ChangeLog').read_text()
+    matches = list(HEADER_RE.finditer(text))
+    if not matches:
+        sys.exit('no version headers found in ChangeLog')
+    top = matches[0]
+    body_end = matches[1].start() if len(matches) > 1 else len(text)
+    body = text[top.end() : body_end].strip('\n')
+    return top.group(1), body
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        '--target',
+        help='Expected version; abort if __version__/ChangeLog disagree.',
+    )
+    args = parser.parse_args()
+
+    version = read_version()
+    cl_version, cl_body = read_top_changelog_section()
+
+    if version != cl_version:
+        sys.exit(
+            f'__version__ is {version!r} but the top ChangeLog section is '
+            f'{cl_version!r}; did the release PR land?'
+        )
+    if args.target and args.target != version:
+        sys.exit(
+            f'--target {args.target!r} does not match current release '
+            f'{version!r}; check out master after the release PR merges.'
+        )
+
+    print(cl_body)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Adds a "Releasing (maintainers only)" section to the README documenting the full flow we just used to cut v4.0.1, and lands the release-notes generator under `scripts/` so it lives with the project.

The helper reads `__version__` and the topmost `ChangeLog` section, and refuses to print anything when they disagree or when `--target` doesn't match — so notes can't accidentally be published for a version whose release PR hasn't landed.

## Test plan
- [x] `python scripts/release-notes.py --target 4.0.1` reproduces the v4.0.1 release notes
- [x] `python scripts/release-notes.py --target 9.9.9` exits non-zero with a clear message