### PR TITLE
Build release artifacts via python -m build

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -16,9 +16,9 @@ jobs:
         name: Install Python
         with:
           python-version: '3.13'
-      - run: pip install setuptools wheel
+      - run: pip install build
       - name: Build wheels
-        run: python setup.py bdist_wheel
+        run: python -m build --wheel
       - uses: actions/upload-artifact@v7
         with:
           path: dist/*.whl
@@ -33,9 +33,9 @@ jobs:
         name: Install Python
         with:
           python-version: '3.13'
-      - run: pip install setuptools
+      - run: pip install build
       - name: Build sdist
-        run: python setup.py sdist
+        run: python -m build --sdist
       - uses: actions/upload-artifact@v7
         with:
           path: dist/*.tar.gz


### PR DESCRIPTION
## Summary
The v4.0.1 release-wheels run failed because #244 removed setup.py in favor of pyproject.toml, but release-wheels.yml was still invoking python setup.py bdist_wheel and python setup.py sdist. The wheel build aborted before the PyPI upload step ran, so PyPI is still on 4.0.0 even though the v4.0.1 GitHub release exists.

Switch both jobs to PEP 517 builds via the `build` package, which respects pyproject.toml's build-system table.

## Test plan
- [x] python -m build --wheel and --sdist run successfully against the current tree locally and produce aiodns-4.0.1-py3-none-any.whl and aiodns-4.0.1.tar.gz

## Follow up
After this merges we re-cut as 4.0.2