### PR TITLE
Release 4.0.2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+4.0.2
+=====
+- Re-release of 4.0.1; the 4.0.1 wheel build failed because the release workflow still invoked ``python setup.py`` after #244 removed ``setup.py``, so 4.0.1 never reached PyPI. The release workflow now uses ``python -m build`` (#248).
+
 4.0.1
 =====
 - Fix ``Future exception was never retrieved`` when pycares raises ``AresError`` synchronously, e.g. for malformed hostnames (#245, fixes #231)

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -32,7 +32,7 @@ from .compat import (
     convert_result,
 )
 
-__version__ = '4.0.1'
+__version__ = '4.0.2'
 
 __all__ = (
     'DNSResolver',


### PR DESCRIPTION
## 4.0.2

- Re-release of 4.0.1; the 4.0.1 wheel build failed because the release workflow still invoked `python setup.py` after #244 removed `setup.py`, so 4.0.1 never reached PyPI. The release workflow now uses `python -m build` (#248).