### PR TITLE
Add license identifier to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers=[
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
     'Programming Language :: Python :: 3.14',
-    'License :: OSI Approved :: MIT License',
 ]
 dependencies = [
     "pycares>=5.0.0,<6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ dynamic = ["version"]
 requires-python = ">=3.10"
 readme.content-type = "text/x-rst"
 readme.file = "README.rst"
+license = "MIT"
 description = "Simple DNS resolver for asyncio"
 authors = [
     { name = "Saúl Ibarra Corretgé", email = "s@saghul.net" }
@@ -20,6 +21,7 @@ classifiers=[
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
     'Programming Language :: Python :: 3.14',
+    'License :: OSI Approved :: MIT License',
 ]
 dependencies = [
     "pycares>=5.0.0,<6",


### PR DESCRIPTION
## Summary

The migration to `pyproject.toml` in #244 dropped the license metadata. This PR adds:

- The [PEP 639](https://peps.python.org/pep-0639/) SPDX license expression (`license = "MIT"`)
- The `License :: OSI Approved :: MIT License` trove classifier

This ensures the license is properly reported on PyPI and by packaging tools.