### PR TITLE
Release 4.0.3

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+4.0.3
+=====
+- Restore license metadata that was dropped during the ``pyproject.toml`` migration in #244, so packaging tools again detect aiodns as MIT-licensed (#250).
+
 4.0.2
 =====
 - Re-release of 4.0.1; the 4.0.1 wheel build failed because the release workflow still invoked ``python setup.py`` after #244 removed ``setup.py``, so 4.0.1 never reached PyPI. The release workflow now uses ``python -m build`` (#248).

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -32,7 +32,7 @@ from .compat import (
     convert_result,
 )
 
-__version__ = '4.0.2'
+__version__ = '4.0.3'
 
 __all__ = (
     'DNSResolver',


### PR DESCRIPTION
- Restores the MIT license metadata that was dropped during the `pyproject.toml` migration in #244, so packaging tools (and downstream consumers like Home Assistant's license check) again detect aiodns as MIT-licensed.