### PR TITLE
Add missing `build-backend` to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ version = {attr = "aiodns.__version__"}
 [build-system]
 # pycares required because of the fact that it's in the __init__ module
 requires = ["setuptools", "pycares"]
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 # Disables inclusion of non-package data (like tests) in the wheel if they are in the sdist


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add the missing `build-backend` entry to `pyproject.toml`, to fix building with tools that strictly implement PEP 517.  PEP 517 requires the entry to be present, providing a fallback to the deprecated legacy setuptools backend _if_ `setup.py` is present, which is not the case here.

## Are there changes in behavior for the user?

Building from source distribution starts working for some users.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
