### PR TITLE
Note in release docs to skip Dependabot bumps in ChangeLog

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,6 +154,9 @@ Releases are cut from ``master`` and published to PyPI automatically by the
    (``X.Y.Z`` header underlined with ``=``). Open the PR with the title
    ``Release X.Y.Z`` and merge it once CI is green.
 
+   Skip Dependabot bumps for dev tooling and CI actions; keep runtime
+   dependency bumps such as ``pycares``.
+
 2. **Tag and publish the release.** From a clean checkout of ``master`` that
    includes the merged release PR, generate the release notes from
    ``ChangeLog`` and create the GitHub release in one shot::


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Document that Dependabot bumps for dev tooling and CI actions stay out of ChangeLog; only runtime dependency bumps such as pycares belong there.

## Are there changes in behavior for the user?

No, docs only.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes