### PR TITLE
Raise ARES_ENODATA when convert_result has no matching records

### DIFF
--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -202,8 +202,13 @@ class DNSResolver:
             fut.set_exception(
                 error.DNSError(errorno, pycares.errno.strerror(errorno))
             )
+            return
+        try:
+            converted = convert_result(result, qtype)
+        except error.DNSError as exc:
+            fut.set_exception(exc)
         else:
-            fut.set_result(convert_result(result, qtype))
+            fut.set_result(converted)
 
     def _get_query_future_callback(
         self, qtype: int

--- a/aiodns/compat.py
+++ b/aiodns/compat.py
@@ -12,6 +12,16 @@ from typing import Union, cast
 
 import pycares
 
+from . import error
+
+_SINGLE_RESULT_QTYPES = frozenset(
+    {
+        pycares.QUERY_TYPE_CNAME,
+        pycares.QUERY_TYPE_SOA,
+        pycares.QUERY_TYPE_PTR,
+    }
+)
+
 
 def _maybe_str(data: bytes) -> str | bytes:
     """Decode bytes as ASCII, return bytes if decode fails (pycares 4.x)."""
@@ -260,13 +270,19 @@ def convert_result(dns_result: pycares.DNSResult, qtype: int) -> QueryResult:
         converted = _convert_record(record)
 
         # CNAME, SOA, and PTR return single result, not list
-        if record_type in (
-            pycares.QUERY_TYPE_CNAME,
-            pycares.QUERY_TYPE_SOA,
-            pycares.QUERY_TYPE_PTR,
-        ):
+        if record_type in _SINGLE_RESULT_QTYPES:
             return cast(QueryResult, converted)
 
         results.append(converted)
+
+    # NOERROR/NODATA: c-ares delivered ARES_SUCCESS but the answer has no
+    # records of the queried type. pycares 4.x raised ARES_ENODATA here;
+    # without this branch single-result qtypes (CNAME/SOA/PTR) would
+    # resolve to [] and crash callers reading .name/.cname/.nsname.
+    if not results:
+        raise error.DNSError(
+            pycares.errno.ARES_ENODATA,
+            pycares.errno.strerror(pycares.errno.ARES_ENODATA),
+        )
 
     return results

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -1398,6 +1398,24 @@ async def test_query_callback_error() -> None:
     resolver._closed = True
 
 
+@pytest.mark.asyncio
+async def test_query_callback_empty_result_raises_enodata() -> None:
+    """convert_result raising must route through fut.set_exception."""
+    resolver = aiodns.DNSResolver(timeout=5.0)
+    fut: asyncio.Future[Any] = asyncio.get_event_loop().create_future()
+
+    empty = unittest.mock.MagicMock(spec=pycares.DNSResult)
+    empty.answer = []
+
+    resolver._query_callback(fut, pycares.QUERY_TYPE_PTR, empty, None)
+
+    with pytest.raises(aiodns.error.DNSError) as exc_info:
+        fut.result()
+    assert exc_info.value.args[0] == pycares.errno.ARES_ENODATA
+
+    resolver._closed = True
+
+
 async def _assert_malformed_name_routes_through_future(
     fut: asyncio.Future[Any],
 ) -> None:

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -9,6 +9,7 @@ from typing import Any
 import pycares
 import pytest
 
+from aiodns import error
 from aiodns.compat import (
     AresHostResult,
     AresQueryAAAAResult,
@@ -506,11 +507,51 @@ class TestConvertResult:
         assert isinstance(result[0], AresQueryAResult)
         assert isinstance(result[1], AresQueryMXResult)
 
-    def test_convert_empty_result(self) -> None:
-        """Test conversion of empty DNS result."""
+    @pytest.mark.parametrize(
+        'qtype',
+        [
+            pycares.QUERY_TYPE_A,
+            pycares.QUERY_TYPE_AAAA,
+            pycares.QUERY_TYPE_CAA,
+            pycares.QUERY_TYPE_CNAME,
+            pycares.QUERY_TYPE_MX,
+            pycares.QUERY_TYPE_NAPTR,
+            pycares.QUERY_TYPE_NS,
+            pycares.QUERY_TYPE_PTR,
+            pycares.QUERY_TYPE_SOA,
+            pycares.QUERY_TYPE_SRV,
+            pycares.QUERY_TYPE_TXT,
+        ],
+    )
+    def test_convert_empty_result_raises_enodata(self, qtype: int) -> None:
+        """NOERROR/NODATA must raise ARES_ENODATA; see aiodns_bug.md."""
         dns_result = make_mock_dns_result([])
 
-        result = convert_result(dns_result, pycares.QUERY_TYPE_A)
+        with pytest.raises(error.DNSError) as exc_info:
+            convert_result(dns_result, qtype)
 
-        assert isinstance(result, list)
-        assert len(result) == 0
+        assert exc_info.value.args[0] == pycares.errno.ARES_ENODATA
+
+    def test_convert_ptr_with_only_non_ptr_records_raises_enodata(
+        self,
+    ) -> None:
+        """PTR query whose answer carries only a CNAME chain must raise."""
+        cname_data = unittest.mock.MagicMock()
+        cname_data.cname = 'alias.example.com'
+        records = [
+            make_mock_record(pycares.QUERY_TYPE_CNAME, cname_data, ttl=300),
+        ]
+        dns_result = make_mock_dns_result(records)
+
+        with pytest.raises(error.DNSError) as exc_info:
+            convert_result(dns_result, pycares.QUERY_TYPE_PTR)
+
+        assert exc_info.value.args[0] == pycares.errno.ARES_ENODATA
+
+    def test_convert_any_empty_result_returns_empty_list(self) -> None:
+        """ANY is always list-shaped, so empty stays empty (no raise)."""
+        dns_result = make_mock_dns_result([])
+
+        result = convert_result(dns_result, pycares.QUERY_TYPE_ANY)
+
+        assert result == []


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

`convert_result` used to return `[]` whenever the answer section had no records matching the requested qtype (NOERROR/NODATA, or only records of other types). For CNAME, SOA, and PTR that crashed callers reading `.name`, `.cname`, or `.nsname`; for the other qtypes it silently diverged from the pycares 4.x raise on NODATA contract this compat layer is meant to preserve. It now raises `DNSError(ARES_ENODATA)`, and `_query_callback` routes that through `set_exception`. ANY is unchanged.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

Yes; `query()` for qtypes other than ANY will raise `aiodns.error.DNSError(ARES_ENODATA)` on NODATA answers instead of returning an empty list or, for CNAME/SOA/PTR, crashing the caller with `AttributeError`. Matches the pycares 4.x behaviour.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes