### PR TITLE
add plumbing to support HTTPS and TLSA records

### DIFF
--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -21,12 +21,14 @@ from .compat import (
     AresQueryAResult,
     AresQueryCAAResult,
     AresQueryCNAMEResult,
+    AresQueryHTTPSResult,
     AresQueryMXResult,
     AresQueryNAPTRResult,
     AresQueryNSResult,
     AresQueryPTRResult,
     AresQuerySOAResult,
     AresQuerySRVResult,
+    AresQueryTLSAResult,
     AresQueryTXTResult,
     QueryResult,
     convert_result,
@@ -54,12 +56,14 @@ query_type_map = {
     'ANY': pycares.QUERY_TYPE_ANY,
     'CAA': pycares.QUERY_TYPE_CAA,
     'CNAME': pycares.QUERY_TYPE_CNAME,
+    'HTTPS': pycares.QUERY_TYPE_HTTPS,
     'MX': pycares.QUERY_TYPE_MX,
     'NAPTR': pycares.QUERY_TYPE_NAPTR,
     'NS': pycares.QUERY_TYPE_NS,
     'PTR': pycares.QUERY_TYPE_PTR,
     'SOA': pycares.QUERY_TYPE_SOA,
     'SRV': pycares.QUERY_TYPE_SRV,
+    'TLSA': pycares.QUERY_TYPE_TLSA,
     'TXT': pycares.QUERY_TYPE_TXT,
 }
 
@@ -264,6 +268,10 @@ class DNSResolver:
     ) -> asyncio.Future[AresQueryCNAMEResult]: ...
     @overload
     def query(
+        self, host: str, qtype: Literal['HTTPS'], qclass: str | None = ...
+    ) -> asyncio.Future[list[AresQueryHTTPSResult]]: ...
+    @overload
+    def query(
         self, host: str, qtype: Literal['MX'], qclass: str | None = ...
     ) -> asyncio.Future[list[AresQueryMXResult]]: ...
     @overload
@@ -286,6 +294,10 @@ class DNSResolver:
     def query(
         self, host: str, qtype: Literal['SRV'], qclass: str | None = ...
     ) -> asyncio.Future[list[AresQuerySRVResult]]: ...
+    @overload
+    def query(
+        self, host: str, qtype: Literal['TLSA'], qclass: str | None = ...
+    ) -> asyncio.Future[list[AresQueryTLSAResult]]: ...
     @overload
     def query(
         self, host: str, qtype: Literal['TXT'], qclass: str | None = ...

--- a/aiodns/compat.py
+++ b/aiodns/compat.py
@@ -56,6 +56,16 @@ class AresQueryCNAMEResult:
 
 
 @dataclass(frozen=True, slots=True)
+class AresQueryHTTPSResult:
+    """HTTPS record result (pycares 4.x compat)."""
+
+    priority: int
+    target: str
+    params: list[tuple[int, bytes]]
+    ttl: int
+
+
+@dataclass(frozen=True, slots=True)
 class AresQueryMXResult:
     """MX record result (pycares 4.x compat)."""
 
@@ -69,6 +79,17 @@ class AresQueryNSResult:
     """NS record result (pycares 4.x compat)."""
 
     host: str
+    ttl: int
+
+
+@dataclass(frozen=True, slots=True)
+class AresQueryTLSAResult:
+    """TLSA record result (pycares 4.x compat)."""
+
+    cert_usage: int
+    selector: int
+    matching_type: int
+    cert_association_data: bytes
     ttl: int
 
 
@@ -151,8 +172,10 @@ ConvertedRecord = Union[
     AresQueryAResult,
     AresQueryAAAAResult,
     AresQueryCNAMEResult,
+    AresQueryHTTPSResult,
     AresQueryMXResult,
     AresQueryNSResult,
+    AresQueryTLSAResult,
     AresQueryTXTResult,
     AresQuerySOAResult,
     AresQuerySRVResult,
@@ -167,8 +190,10 @@ QueryResult = Union[
     list[AresQueryAResult],
     list[AresQueryAAAAResult],
     AresQueryCNAMEResult,
+    list[AresQueryHTTPSResult],
     list[AresQueryMXResult],
     list[AresQueryNSResult],
+    list[AresQueryTLSAResult],
     list[AresQueryTXTResult],
     AresQuerySOAResult,
     list[AresQuerySRVResult],
@@ -247,6 +272,23 @@ def _convert_record(record: pycares.DNSRecord) -> ConvertedRecord:
     if record_type == pycares.QUERY_TYPE_PTR:
         ptr_data = cast(pycares.PTRRecordData, record.data)
         return AresQueryPTRResult(name=ptr_data.dname, ttl=ttl, aliases=[])
+    if record_type == pycares.QUERY_TYPE_HTTPS:
+        https_data = cast(pycares.HTTPSRecordData, record.data)
+        return AresQueryHTTPSResult(
+            priority=https_data.priority,
+            target=https_data.target,
+            params=https_data.params,
+            ttl=ttl,
+        )
+    if record_type == pycares.QUERY_TYPE_TLSA:
+        tlsa_data = cast(pycares.TLSARecordData, record.data)
+        return AresQueryTLSAResult(
+            cert_usage=tlsa_data.cert_usage,
+            selector=tlsa_data.selector,
+            matching_type=tlsa_data.matching_type,
+            cert_association_data=tlsa_data.cert_association_data,
+            ttl=ttl,
+        )
     # Return raw record for unknown types
     return record
 

--- a/tests/test_aiodns.py
+++ b/tests/test_aiodns.py
@@ -21,12 +21,14 @@ from aiodns.compat import (
     AresQueryAAAAResult,
     AresQueryAResult,
     AresQueryCNAMEResult,
+    AresQueryHTTPSResult,
     AresQueryMXResult,
     AresQueryNAPTRResult,
     AresQueryNSResult,
     AresQueryPTRResult,
     AresQuerySOAResult,
     AresQuerySRVResult,
+    AresQueryTLSAResult,
     AresQueryTXTResult,
 )
 
@@ -140,6 +142,20 @@ class DNSTest(unittest.TestCase):
         self.assertTrue(result)
         self.assertIsInstance(result, list)
         self.assertIsInstance(result[0], AresQuerySRVResult)
+
+    def test_query_https(self) -> None:
+        f = self.resolver.query('cloudflare.com', 'HTTPS')
+        result = self.loop.run_until_complete(f)
+        self.assertTrue(result)
+        self.assertIsInstance(result, list)
+        self.assertIsInstance(result[0], AresQueryHTTPSResult)
+
+    def test_query_tlsa(self) -> None:
+        f = self.resolver.query('_25._tcp.mail.ietf.org', 'TLSA')
+        result = self.loop.run_until_complete(f)
+        self.assertTrue(result)
+        self.assertIsInstance(result, list)
+        self.assertIsInstance(result[0], AresQueryTLSAResult)
 
     def test_query_naptr(self) -> None:
         f = self.resolver.query('sip2sip.info', 'NAPTR')


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add support to query HTTPS and TLSA records

## Are there changes in behavior for the user?

Added support for both query and query_dns, including the 4.x compat classes

## Related issue number

Solves #257 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [?] Documentation reflects the changes
